### PR TITLE
remove globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,11 +14,6 @@ module.exports =  {
     "node": true
   },
 
-  "globals": {
-    "document": "readonly",
-    "window": "readonly"
-  },
-
   "rules": {
     "no-multiple-empty-lines": ["error", {
       "max": 2,


### PR DESCRIPTION
I've documented in README what to do when linting client-side scripts; the globals missed fetch and that's how I noticed. The globals should therefore be unnecessary.