### PR TITLE
quote-props to be consistent-as-needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
       maxEOF: 0,
     }],
     'comma-dangle': ['error', 'always-multiline'],
+    'quote-props': ['error', 'consistent-as-needed'],
     'space-before-function-paren': ['error', {
       anonymous: 'always',
       named: 'never',

--- a/tests/files/quote-props-bad.js
+++ b/tests/files/quote-props-bad.js
@@ -1,0 +1,4 @@
+console.log({
+  files: 1,
+  'text/plain': 2,
+});

--- a/tests/files/quote-props-good.js
+++ b/tests/files/quote-props-good.js
@@ -1,0 +1,4 @@
+console.log({
+  'files': 1,
+  'text/plain': 2,
+});


### PR DESCRIPTION
In this case...
```
const handlers = {
  'Files': handleFileDrag,
  'text/plain': handleTextDrag,
};
```

the first second property must be quoted, but the first may not be, and it's cleaner in most circumstances to not use property name quotes in code (as opposed to in a JSON file).  [consistent-as-needed](https://eslint.org/docs/rules/quote-props) seems to be our best options here.