### PR TITLE
Should use root option if root of project

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ env:
   browser: true
 ```
 
+Add the following option to your `.eslintrc.yml` to declare that it's the root config of the project:
+
+```yaml
+root: true
+```
+
+By default ESLint will append configuration files up the directory tree to the home directory, here is a [link](https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy) for more details.
+
 Happy linting!
 
 ## Contributing

--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ module.exports =  {
     }
   },
 
-  "root": true,
-
   "env": {
     "es6": true,
     "node": true

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ module.exports =  {
     }
   },
 
+  "root": true,
+
   "env": {
     "es6": true,
     "node": true


### PR DESCRIPTION
By default, eslint will go up the directory tree to the root directory appending all eslint rules together. So the `"root": true` rule will tell eslint to stop appending at this point.

