### PR TITLE
From ws_objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,5 +27,8 @@ module.exports = {
       asyncArrow: 'always',
     }],
     'quotes': ['error', 'single', 'avoid-escape'],
+    'lines-between-class-members': ['error', 'always', {
+      exceptAfterSingleLine: true,
+    }],
   },
 };

--- a/index.js
+++ b/index.js
@@ -26,5 +26,6 @@ module.exports = {
       named: 'never',
       asyncArrow: 'always',
     }],
+    'quotes': ['error', 'single', 'avoid-escape'],
   },
 };

--- a/tests/files/lines-between-class-members-bad.js
+++ b/tests/files/lines-between-class-members-bad.js
@@ -1,0 +1,11 @@
+class Example {
+  constructor() {
+    console.log();
+  }
+  // there should be a line between class members
+  method() {
+    console.log();
+  }
+}
+
+console.log((new Example()).theAnswer);

--- a/tests/files/lines-between-class-members-good.js
+++ b/tests/files/lines-between-class-members-good.js
@@ -1,0 +1,16 @@
+class Example {
+  constructor() {
+    console.log();
+  }
+
+  // no line between one-line class members is OK
+  get theAnswer() { return 42; }
+  get message() { return 'hi'; }
+
+  // method() is unused but sadly the linter doesn't catch it yet
+  method() {
+    console.log();
+  }
+}
+
+console.log((new Example()).theAnswer);

--- a/tests/files/quotes-1-bad.js
+++ b/tests/files/quotes-1-bad.js
@@ -1,0 +1,1 @@
+console.log("no double quotes unless there is an apostrophe there");

--- a/tests/files/quotes-2-bad.js
+++ b/tests/files/quotes-2-bad.js
@@ -1,0 +1,1 @@
+console.log(`no backticks without parameters`);

--- a/tests/files/quotes-good.js
+++ b/tests/files/quotes-good.js
@@ -1,0 +1,4 @@
+console.log('single quotes OK');
+console.log("double quotes OK only if there's an apostrophe in them");
+console.log('backslash \' quoting allowed');
+console.log(`backticks OK with at least ${1} parameters`);


### PR DESCRIPTION
* we should disallow use of backticks without need:
  ```js
  let col = `crimson`; // bad, use single quotes
  ```
* we should allow the lack of space between one-line class members:
  ```js
  class Shape {
    #x; // it's ok not to have an empty line between #x and #y 
    #y;

    constructor(x, y) {
      …
    }
  }
  ```